### PR TITLE
no CMakeLists.txt under examples. delete the config from root CMakeLi…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,7 +54,7 @@ include_directories(BEFORE src) # This is needed for gtest.
 add_subdirectory(src/gtest)
 add_subdirectory(src/caffe)
 add_subdirectory(tools)
-add_subdirectory(examples)
+# add_subdirectory(examples)
 add_subdirectory(python)
 add_subdirectory(matlab)
 add_subdirectory(docs)


### PR DESCRIPTION
…sts.txt